### PR TITLE
Restrict CODEOWNERS to cg-maintainers-dsp-bidding-systems

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Managed through github.com/adgear/lepage ux53
+#
+# Ownership for this component group team
+*   @adgear/cg-maintainers-dsp-bidding-systems
+
+# Pull in the architecture team for ADR reviews
+/doc/architecture/ @adgear/prac-architecture
+/doc/adr/ @adgear/prac-architecture
+
+# Pull in the SREs on technical doc reviews
+RUNBOOK.md @adgear/prac-sre
+
+# deploy stuff (prometheus for now)
+/deploy/ @adgear/prac-sre


### PR DESCRIPTION
Ticket: [DEGA-1629](https://adgear.atlassian.net/browse/DEGA-1629)

Only the Gatekeepers team should be able to approve some PRs as the maintainers of the project.

_This is an automatic pull request opened with [adgear/lepage ux53](https://github.com/adgear/lepage)_.

[DEGA-1629]: https://adgear.atlassian.net/browse/DEGA-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ