### PR TITLE
make 'erl_betree:betree_search_ids/4' return type consistent across function clause heads

### DIFF
--- a/src/erl_betree.erl
+++ b/src/erl_betree.erl
@@ -59,7 +59,7 @@ betree_search_ids(Betree, Event, Ids) ->
 % Also calculates time spend in NIF. 
 % Time value is in microseconds - the erlang:timestamp resolution.  
 betree_search_ids(_Betree, _Event, [], _CLockType)  ->
-    {0, []};
+    {{ok, []}, 0};
 betree_search_ids(Betree, Event, Ids, ClockType) when is_list(Event), is_integer(ClockType) ->
     erl_betree_nif:betree_search_ids(Betree, Event, Ids, ClockType);
 betree_search_ids(Betree, Event, Ids, ClockType) when is_reference(Event), is_integer(ClockType) ->

--- a/test/betree_search_tests.erl
+++ b/test/betree_search_tests.erl
@@ -304,6 +304,38 @@ three_betrees_search_ids_test() ->
   {{ok, Matched3}, _} = Ret_betree3_search_ids,
   ?assertEqual([1], Matched3).
 
+search_empty_list_of_ids_test() ->
+  Domains = [[
+    {par1,bool,disallow_undefined},
+    {par2,bool,disallow_undefined}
+  ]],
+  {ok, Betree1} = erl_betree:betree_make(Domains),
+  Expr1 = <<"par1">>,
+  {ok, Sub1} = erl_betree:betree_make_sub(Betree1, 1, [], Expr1),
+  ok = erl_betree:betree_insert_sub(Betree1, Sub1),
+
+  {ok, Betree2} = erl_betree:betree_make(Domains),
+  Expr2 = <<"par2">>,
+  {ok, Sub2} = erl_betree:betree_make_sub(Betree2, 1, [], Expr2),
+  ok = erl_betree:betree_insert_sub(Betree2, Sub2),
+
+  Event = [{bool_event, true, true}],
+  Ret_betree_make_event = erl_betree:betree_make_event(Betree1, Event),
+  ?assertMatch({{ok, _}, _}, Ret_betree_make_event),
+  {{ok, Evt}, _} = Ret_betree_make_event,
+
+  Ret_betree1_search = erl_betree:betree_search(Betree1, Evt, 0),
+  ?assertMatch({{ok, _}, _}, Ret_betree1_search),
+  {{ok, Matched1}, _} = Ret_betree1_search,
+  ?assertEqual([1], Matched1),
+
+  % Search empty list of Ids
+  Ret_betree2_search_ids = erl_betree:betree_search_ids(Betree2, Evt, [], 0),
+  ?assertMatch({{ok, _}, _}, Ret_betree2_search_ids),
+  {{ok, Matched2}, Elapsed} = Ret_betree2_search_ids,
+  ?assertEqual([], Matched2),
+  ?assertEqual(0, Elapsed).
+
 not_and_test() ->
   Params = [
     {p1, bool, disallow_undefined},


### PR DESCRIPTION
Test added `search_empty_list_of_ids_test`.